### PR TITLE
Grey circle for disabled SpectrumPreference

### DIFF
--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -6,7 +6,7 @@
         android:defaultValue="@color/md_indigo_500"
         android:key="demo_preference_1"
         android:summary="This is pretty cool."
-        android:title="Color reference"
+        android:title="Color preference"
         app:spectrum_colors="@array/demo_colors"
         app:spectrum_borderWidth="2dp"/>
 
@@ -26,6 +26,18 @@
         android:title="Fixed column count"
         app:spectrum_closeOnSelected="false"
         app:spectrum_columnCount="4"
+        app:spectrum_colors="@array/demo_colors" />
+
+    <CheckBoxPreference
+        android:key="enable_demo_preference_4"
+        android:title="Enable preference below"/>
+
+    <com.thebluealliance.spectrum.SpectrumPreferenceCompat
+        android:defaultValue="@color/md_red_500"
+        android:dependency="enable_demo_preference_4"
+        android:key="demo_preference_4"
+        android:summary="When this preference is disabled, the preview changes to gray"
+        android:title="Preference that can be disabled"
         app:spectrum_colors="@array/demo_colors" />
 
 </PreferenceScreen>

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -1,7 +1,5 @@
 package com.thebluealliance.spectrum;
 
-import com.thebluealliance.spectrum.internal.ColorCircleDrawable;
-
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -14,9 +12,13 @@ import android.support.annotation.ColorInt;
 import android.util.AttributeSet;
 import android.view.View;
 
+import com.thebluealliance.spectrum.internal.ColorCircleDrawable;
+
 public class SpectrumPreference extends DialogPreference {
 
     private static final @ColorInt int DEFAULT_VALUE = Color.BLACK;
+    public static final int ALPHA_ENABLED = 255;
+    public static final int ALPHA_DISABLED = 127;
 
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;
@@ -118,6 +120,7 @@ public class SpectrumPreference extends DialogPreference {
         }
         ColorCircleDrawable drawable = new ColorCircleDrawable(mCurrentValue);
         drawable.setBorderWidth(mBorderWidth);
+        drawable.setAlpha(isEnabled() ? ALPHA_ENABLED :  ALPHA_DISABLED);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             mColorView.setBackground(drawable);
         } else {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -17,8 +17,7 @@ import com.thebluealliance.spectrum.internal.ColorCircleDrawable;
 public class SpectrumPreference extends DialogPreference {
 
     private static final @ColorInt int DEFAULT_VALUE = Color.BLACK;
-    public static final int ALPHA_ENABLED = 255;
-    public static final int ALPHA_DISABLED = 150;
+    public static final int ALPHA_DISABLED = 97; //38% alpha
 
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;
@@ -120,7 +119,10 @@ public class SpectrumPreference extends DialogPreference {
         }
         ColorCircleDrawable drawable = new ColorCircleDrawable(mCurrentValue);
         drawable.setBorderWidth(mBorderWidth);
-        drawable.setAlpha(isEnabled() ? ALPHA_ENABLED :  ALPHA_DISABLED);
+        if (!isEnabled()) {
+            drawable.setColor(Color.BLACK);
+            drawable.setAlpha(ALPHA_DISABLED);
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             mColorView.setBackground(drawable);
         } else {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -18,7 +18,7 @@ public class SpectrumPreference extends DialogPreference {
 
     private static final @ColorInt int DEFAULT_VALUE = Color.BLACK;
     public static final int ALPHA_ENABLED = 255;
-    public static final int ALPHA_DISABLED = 127;
+    public static final int ALPHA_DISABLED = 150;
 
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -45,7 +45,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
 
     private static final @ColorInt int DEFAULT_VALUE = Color.BLACK;
     public static final int ALPHA_ENABLED = 255;
-    public static final int ALPHA_DISABLED = 127;
+    public static final int ALPHA_DISABLED = 150;
 
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -1,8 +1,5 @@
 package com.thebluealliance.spectrum;
 
-import com.thebluealliance.spectrum.internal.ColorCircleDrawable;
-import com.thebluealliance.spectrum.internal.SpectrumPreferenceDialogFragmentCompat;
-
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -16,6 +13,9 @@ import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 import android.view.View;
+
+import com.thebluealliance.spectrum.internal.ColorCircleDrawable;
+import com.thebluealliance.spectrum.internal.SpectrumPreferenceDialogFragmentCompat;
 
 /**
  * A version of {@link SpectrumPreference} meant to be used with the support library Preferences.
@@ -44,6 +44,8 @@ public class SpectrumPreferenceCompat extends DialogPreference {
     private static final String DIALOG_FRAGMENT_TAG = "android.support.v7.preference.PreferenceFragment.DIALOG";
 
     private static final @ColorInt int DEFAULT_VALUE = Color.BLACK;
+    public static final int ALPHA_ENABLED = 255;
+    public static final int ALPHA_DISABLED = 127;
 
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;
@@ -133,6 +135,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
         }
         ColorCircleDrawable drawable = new ColorCircleDrawable(mCurrentValue);
         drawable.setBorderWidth(mBorderWidth);
+        drawable.setAlpha(isEnabled() ? ALPHA_ENABLED :  ALPHA_DISABLED);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             mColorView.setBackground(drawable);
         } else {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -44,8 +44,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
     private static final String DIALOG_FRAGMENT_TAG = "android.support.v7.preference.PreferenceFragment.DIALOG";
 
     private static final @ColorInt int DEFAULT_VALUE = Color.BLACK;
-    public static final int ALPHA_ENABLED = 255;
-    public static final int ALPHA_DISABLED = 150;
+    public static final int ALPHA_DISABLED = 97; //38% alpha
 
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;
@@ -135,7 +134,10 @@ public class SpectrumPreferenceCompat extends DialogPreference {
         }
         ColorCircleDrawable drawable = new ColorCircleDrawable(mCurrentValue);
         drawable.setBorderWidth(mBorderWidth);
-        drawable.setAlpha(isEnabled() ? ALPHA_ENABLED :  ALPHA_DISABLED);
+        if (!isEnabled()) {
+            drawable.setColor(Color.BLACK);
+            drawable.setAlpha(ALPHA_DISABLED);
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             mColorView.setBackground(drawable);
         } else {


### PR DESCRIPTION
Show a grey circle (actually black @ 38% alpha) for a disabled preference
