### PR TITLE
Proguard fix for @Subscribe methods

### DIFF
--- a/spectrum/build.gradle
+++ b/spectrum/build.gradle
@@ -35,6 +35,7 @@ android {
         targetSdkVersion 23
         versionCode libraryVersionCode
         versionName libraryVersion
+        consumerProguardFiles 'proguard-rules.pro'
     }
     buildTypes {
         release {

--- a/spectrum/proguard-rules.pro
+++ b/spectrum/proguard-rules.pro
@@ -15,3 +15,13 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# From http://stackoverflow.com/a/31567519/3995632
+# Ensure annotations are kept for runtime use.
+-keepattributes *Annotation*
+# Don't remove any GreenRobot classes
+-keep class org.greenrobot.** {*;}
+# Don't remove any methods that have the @Subscribe annotation
+-keepclassmembers class ** {
+    @org.greenrobot.eventbus.Subscribe <methods>;
+}


### PR DESCRIPTION
When Proguard is used on release builds, SpectrumPalette#onSelectedColorChaxnged(SelectedColorChangedEvent event) gets removed, which triggers the following exception:

```
04-26 21:17:22.604 E/Xposed  ( 5256): xposeddatausage/Thread main threw uncaught exception/android.view.InflateException: Binary XML file line #7: Binary XML file line #7: Error inflating class com.    thebluealliance.spectrum.SpectrumPalette
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.inflate(LayoutInflater.java:539)
04-26 21:17:22.604 E/Xposed  ( 5256):   at de.robv.android.xposed.XposedBridge.invokeOriginalMethodNative(Native Method)
04-26 21:17:22.604 E/Xposed  ( 5256):   at de.robv.android.xposed.XposedBridge.handleHookedMethod(XposedBridge.java:738)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.inflate(<Xposed>)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.inflate(LayoutInflater.java:423)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.inflate(LayoutInflater.java:374)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.preference.DialogPreference.onCreateDialogView(DialogPreference.java:354)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.preference.DialogPreference.showDialog(DialogPreference.java:298)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.preference.DialogPreference.onClick(DialogPreference.java:277)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.preference.Preference.performClick(Preference.java:994)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.preference.PreferenceScreen.onItemClick(PreferenceScreen.java:214)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.widget.AdapterView.performItemClick(AdapterView.java:310)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.widget.AbsListView.performItemClick(AbsListView.java:1145)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.widget.AbsListView$PerformClick.run(AbsListView.java:3066)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.widget.AbsListView$3.run(AbsListView.java:3903)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.os.Handler.handleCallback(Handler.java:739)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.os.Handler.dispatchMessage(Handler.java:95)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.os.Looper.loop(Looper.java:148)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.app.ActivityThread.main(ActivityThread.java:5417)
04-26 21:17:22.604 E/Xposed  ( 5256):   at java.lang.reflect.Method.invoke(Native Method)
04-26 21:17:22.604 E/Xposed  ( 5256):   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
04-26 21:17:22.604 E/Xposed  ( 5256):   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
04-26 21:17:22.604 E/Xposed  ( 5256):   at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:134)
04-26 21:17:22.604 E/Xposed  ( 5256): Caused by: android.view.InflateException: Binary XML file line #7: Error inflating class com.thebluealliance.spectrum.SpectrumPalette
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.createView(LayoutInflater.java:645)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:764)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:704)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.rInflate(LayoutInflater.java:835)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:798)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.inflate(LayoutInflater.java:515)
04-26 21:17:22.604 E/Xposed  ( 5256):   ... 22 more
04-26 21:17:22.604 E/Xposed  ( 5256): Caused by: java.lang.reflect.InvocationTargetException
04-26 21:17:22.604 E/Xposed  ( 5256):   at java.lang.reflect.Constructor.newInstance(Native Method)
04-26 21:17:22.604 E/Xposed  ( 5256):   at android.view.LayoutInflater.createView(LayoutInflater.java:619)
04-26 21:17:22.604 E/Xposed  ( 5256):   ... 27 more
04-26 21:17:22.604 E/Xposed  ( 5256): Caused by: org.greenrobot.eventbus.EventBusException: Subscriber class com.thebluealliance.spectrum.SpectrumPalette and its super classes have no public methods     with the @Subscribe annotation
04-26 21:17:22.604 E/Xposed  ( 5256):   at org.greenrobot.eventbus.SubscriberMethodFinder.findSubscriberMethods(SubscriberMethodFinder.java:67)
04-26 21:17:22.604 E/Xposed  ( 5256):   at org.greenrobot.eventbus.EventBus.register(EventBus.java:136)
04-26 21:17:22.604 E/Xposed  ( 5256):   at com.thebluealliance.spectrum.SpectrumPalette.init(SpectrumPalette.java:85)
04-26 21:17:22.604 E/Xposed  ( 5256):   at com.thebluealliance.spectrum.SpectrumPalette.<init>(SpectrumPalette.java:80)
04-26 21:17:22.604 E/Xposed  ( 5256):   ... 29 more
```
