### PR TITLE
Forced to update to latest Gradle plugin for Android Studio 2.1 stable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }


### PR DESCRIPTION
Not sure if you want this yet, but AS 2.1 stable will not allow the project to build without it.
