### PR TITLE
Catch external preference changes and update color indicator

### DIFF
--- a/sample/src/main/java/com/thebluealliance/spectrumsample/ExternalColorChangePreference.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/ExternalColorChangePreference.java
@@ -3,7 +3,6 @@ package com.thebluealliance.spectrumsample;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.support.v7.preference.Preference;
-import android.support.v7.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 
 import com.thebluealliance.spectrum.SpectrumPreferenceCompat;
@@ -27,13 +26,15 @@ public class ExternalColorChangePreference extends Preference {
     }
 
     @Override
-    public void onBindViewHolder(PreferenceViewHolder holder) {
-        super.onBindViewHolder(holder);
+    public void onAttached() {
+        super.onAttached();
 
         final SpectrumPreferenceCompat colorPreference = (SpectrumPreferenceCompat) getPreferenceManager().findPreference(mSpectrumPreferenceId);
         final int[] colors = colorPreference.getColors();
-        final NonRepeatingRandom randomGenerator = new NonRepeatingRandom();
+        final NonRepeatingRandom randomGenerator = new NonRepeatingRandom(find(colors, colorPreference.getColor()));
+
         setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 colorPreference.setColor(colors[randomGenerator.nextInt(colors.length)]);
@@ -42,9 +43,20 @@ public class ExternalColorChangePreference extends Preference {
         });
     }
 
+    private int find(int[] array, int value) {
+        for(int i=0; i<array.length; i++)
+            if(array[i] == value)
+                return i;
+        return -1;
+    }
+
     private class NonRepeatingRandom extends Random {
 
-        private int mLastRandomInt = -1;
+        private int mLastRandomInt;
+
+        public NonRepeatingRandom(int lastRandomInt) {
+            mLastRandomInt = lastRandomInt;
+        }
 
         @Override
         public int nextInt(int n) {

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/ExternalColorChangePreference.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/ExternalColorChangePreference.java
@@ -1,0 +1,55 @@
+package com.thebluealliance.spectrumsample;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceViewHolder;
+import android.util.AttributeSet;
+
+import com.thebluealliance.spectrum.SpectrumPreferenceCompat;
+
+import java.util.Random;
+
+public class ExternalColorChangePreference extends Preference {
+
+    private final String mSpectrumPreferenceId;
+
+    public ExternalColorChangePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable
+                .ExternalColorChangePreference, 0, 0);
+        try {
+            mSpectrumPreferenceId = a.getString(R.styleable.ExternalColorChangePreference_spectrum_preference);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        final SpectrumPreferenceCompat colorPreference = (SpectrumPreferenceCompat) getPreferenceManager().findPreference(mSpectrumPreferenceId);
+        final int[] colors = colorPreference.getColors();
+        final NonRepeatingRandom randomGenerator = new NonRepeatingRandom();
+        setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                colorPreference.setColor(colors[randomGenerator.nextInt(colors.length)]);
+                return false;
+            }
+        });
+    }
+
+    private class NonRepeatingRandom extends Random {
+
+        private int mLastRandomInt = -1;
+
+        @Override
+        public int nextInt(int n) {
+            int random = super.nextInt(n);
+            return mLastRandomInt = (random == mLastRandomInt ? nextInt(n) : random);
+        }
+    }
+}

--- a/sample/src/main/res/values/attrs.xml
+++ b/sample/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="ExternalColorChangePreference">
+        <attr name="spectrum_preference" format="string"/>
+        <attr name="spectrum_colors"/>
+    </declare-styleable>
+</resources>

--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -40,4 +40,10 @@
         android:title="Preference that can be disabled"
         app:spectrum_colors="@array/demo_colors" />
 
+    <com.thebluealliance.spectrumsample.ExternalColorChangePreference
+        android:key="change_demo_preference_5"
+        android:title="Change top preference color"
+        android:summary="Color indicator reflects external changes"
+        app:spectrum_preference="demo_preference_1"/>
+
 </PreferenceScreen>

--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -42,8 +42,14 @@
 
     <com.thebluealliance.spectrumsample.ExternalColorChangePreference
         android:key="change_demo_preference_5"
-        android:title="Change top preference color"
+        android:title="Change preference below"
+        app:spectrum_preference="demo_preference_5"/>
+
+    <com.thebluealliance.spectrum.SpectrumPreferenceCompat
+        android:defaultValue="@color/md_green_500"
+        android:key="demo_preference_5"
         android:summary="Color indicator reflects external changes"
-        app:spectrum_preference="demo_preference_1"/>
+        android:title="Color preference"
+        app:spectrum_colors="@array/demo_colors"/>
 
 </PreferenceScreen>

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -25,6 +25,7 @@ public class SpectrumPreference extends DialogPreference {
     private @ColorInt int mCurrentValue;
     private boolean mCloseOnSelected = true;
     private SpectrumPalette mColorPalette;
+    private boolean mValueSet = false;
     private View mColorView;
     private int mOutlineWidth = 0;
     private int mFixedColumnCount = -1;
@@ -104,6 +105,20 @@ public class SpectrumPreference extends DialogPreference {
      */
     public boolean getCloseOnSelected() {
         return mCloseOnSelected;
+    }
+
+    public void setColor(@ColorInt int value) {
+        // Always persist/notify the first time.
+        final boolean changed = mCurrentValue != value;
+        if (changed || !mValueSet) {
+            mCurrentValue = value;
+            mValueSet = true;
+            persistInt(value);
+            updateColorView();
+            if (changed) {
+                notifyChanged();
+            }
+        }
     }
 
     @Override

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -22,6 +22,7 @@ public class SpectrumPreference extends DialogPreference {
     private @ColorInt int[] mColors;
     private @ColorInt int mCurrentValue;
     private boolean mCloseOnSelected = true;
+    private boolean mValueSet = false;
     private SpectrumPalette mColorPalette;
     private View mColorView;
     private int mOutlineWidth = 0;
@@ -73,6 +74,20 @@ public class SpectrumPreference extends DialogPreference {
     public
     @ColorInt int[] getColors() {
         return mColors;
+    }
+
+    public void setValue(@ColorInt int value) {
+        // Always persist/notify the first time.
+        final boolean changed = mCurrentValue != value;
+        if (changed || !mValueSet) {
+            mCurrentValue = value;
+            mValueSet = true;
+            persistInt(value);
+            updateColorView();
+            if (changed) {
+                notifyChanged();
+            }
+        }
     }
 
     /**

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -121,6 +121,11 @@ public class SpectrumPreference extends DialogPreference {
         }
     }
 
+    @ColorInt
+    public int getColor() {
+        return mCurrentValue;
+    }
+
     @Override
     protected View onCreateView(ViewGroup parent) {
         getSharedPreferences().registerOnSharedPreferenceChangeListener(mListener);

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -190,7 +190,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
         return a.getInteger(index, DEFAULT_VALUE);
     }
 
-    public void setValue(@ColorInt int value) {
+    public void setColor(@ColorInt int value) {
         // Always persist/notify the first time.
         final boolean changed = mCurrentValue != value;
         if (changed || !mValueSet) {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -213,7 +213,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
     }
 
     @ColorInt
-    public int getValue() {
+    public int getColor() {
         return mCurrentValue;
     }
 

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -1,6 +1,7 @@
 package com.thebluealliance.spectrum;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.os.Build;
@@ -54,6 +55,15 @@ public class SpectrumPreferenceCompat extends DialogPreference {
     private int mOutlineWidth = 0;
     private int mFixedColumnCount = -1;
 
+    private SharedPreferences.OnSharedPreferenceChangeListener mListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
+        public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
+            if(getKey().equals(key)){
+                mCurrentValue = prefs.getInt(key, mCurrentValue);
+                updateColorView();
+            }
+        }
+    };
+
     public SpectrumPreferenceCompat(Context context, AttributeSet attrs) {
         super(context, attrs);
 
@@ -72,6 +82,19 @@ public class SpectrumPreferenceCompat extends DialogPreference {
 
         setDialogLayoutResource(R.layout.dialog_color_picker);
         setWidgetLayoutResource(R.layout.color_preference_widget);
+
+    }
+
+    @Override
+    public void onAttached() {
+        super.onAttached();
+        getSharedPreferences().registerOnSharedPreferenceChangeListener(mListener);
+    }
+
+    @Override
+    protected void onPrepareForRemoval() {
+        super.onPrepareForRemoval();
+        getSharedPreferences().unregisterOnSharedPreferenceChangeListener(mListener);
     }
 
     @Override

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/SpectrumPreferenceDialogFragmentCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/SpectrumPreferenceDialogFragmentCompat.java
@@ -48,7 +48,7 @@ public class SpectrumPreferenceDialogFragmentCompat extends PreferenceDialogFrag
             throw new RuntimeException("SpectrumPreference requires a colors array");
         }
 
-        mCurrentValue = preference.getValue();
+        mCurrentValue = preference.getColor();
 
         mColorPalette = (SpectrumPalette) view.findViewById(R.id.palette);
         mColorPalette.setColors(getSpectrumPreference().getColors());

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/SpectrumPreferenceDialogFragmentCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/SpectrumPreferenceDialogFragmentCompat.java
@@ -74,7 +74,7 @@ public class SpectrumPreferenceDialogFragmentCompat extends PreferenceDialogFrag
         final SpectrumPreferenceCompat preference = getSpectrumPreference();
         if (positiveResult) {
             if (preference.callChangeListener(mCurrentValue)) {
-                preference.setValue(mCurrentValue);
+                preference.setColor(mCurrentValue);
             }
         }
     }


### PR DESCRIPTION
This public method only appears in the support library Preferences version.
Although not required by SpectrumPreference in the same way that it is in the support version it is a useful method and will keep a consistency between the 2 classes.
