### PR TITLE
Fix typo in method name

### DIFF
--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
@@ -288,7 +288,7 @@ public class SpectrumPalette extends LinearLayout {
     }
 
     @Subscribe
-    public void onSelectedColorChaxnged(SelectedColorChangedEvent event) {
+    public void onSelectedColorChanged(SelectedColorChangedEvent event) {
         mSelectedColor = event.getSelectedColor();
         if (mListener != null) {
             mListener.onColorSelected(mSelectedColor);


### PR DESCRIPTION
Fixes https://github.com/the-blue-alliance/spectrum/issues/28

Fix a typo in method name. `onSelectedColorChaxnged` -> `onSelectedColorChanged`
