### PR TITLE
Added ability to theme the dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
@@ -44,6 +44,13 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
                 return true;
             }
         });
+
+        findPreference("demo_dialog_5").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override public boolean onPreferenceClick(Preference preference) {
+                showDialog5();
+                return true;
+            }
+        });
     }
 
     private void showDialog1() {
@@ -111,5 +118,22 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
                         }
                     }
                 }).build().show(getFragmentManager(), "dialog_demo_4");
+    }
+
+    private void showDialog5() {
+        new SpectrumDialog.Builder(getContext())
+                .setThemeResId(R.style.DialogTheme)
+                .setColors(R.array.demo_colors)
+                .setSelectedColorRes(R.color.md_blue_500)
+                .setDismissOnColorSelected(true)
+                .setOnColorSelectedListener(new SpectrumDialog.OnColorSelectedListener() {
+                    @Override public void onColorSelected(boolean positiveResult, @ColorInt int color) {
+                        if (positiveResult) {
+                            Toast.makeText(getContext(), "Color selected: #" + Integer.toHexString(color).toUpperCase(), Toast.LENGTH_SHORT).show();
+                        } else {
+                            Toast.makeText(getContext(), "Dialog cancelled", Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                }).build().show(getFragmentManager(), "dialog_demo_5");
     }
 }

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
@@ -121,8 +121,7 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
     }
 
     private void showDialog5() {
-        new SpectrumDialog.Builder(getContext())
-                .setThemeResId(R.style.DialogTheme)
+        new SpectrumDialog.Builder(getContext(), R.style.DialogTheme)
                 .setColors(R.array.demo_colors)
                 .setSelectedColorRes(R.color.md_blue_500)
                 .setDismissOnColorSelected(true)

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -16,4 +16,10 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog">
+        <item name="colorAccent">@color/md_green_500</item>
+        <item name="colorControlNormal">@color/md_orange_500</item>
+        <item name="android:background">@color/md_grey_500</item>
+    </style>
+
 </resources>

--- a/sample/src/main/res/xml/demo_dialog.xml
+++ b/sample/src/main/res/xml/demo_dialog.xml
@@ -21,4 +21,9 @@
         android:summary="This demonstrates a dialog with a fixed number of columns (4). This column count will be used no matter how big the screen is."
         android:title="Fixed Column Count" />
 
+    <Preference
+        android:key="demo_dialog_5"
+        android:summary="This demonstrates a dialog with a custom theme."
+        android:title="Custom Theme" />
+
 </PreferenceScreen>

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -56,6 +56,12 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
             mArgs = new Bundle();
         }
 
+        public Builder(Context context, int theme) {
+            mContext = context;
+            mArgs = new Bundle();
+            mArgs.putInt(KEY_THEME_RES_ID, theme);
+        }
+
         /**
          * Sets the dialog's title.
          *
@@ -193,17 +199,6 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
             @ColorInt int color = ContextCompat.getColor(mContext, selectedColorRes);
             mArgs.putInt(KEY_SELECTED_COLOR, color);
             mArgs.putInt(KEY_ORIGINAL_SELECTED_COLOR, color);
-            return this;
-        }
-
-        /**
-         * Provides a resource that will be used to style to the dialog. See
-         * {@link AlertDialog#AlertDialog(Context, int)}.
-         *
-         * @return This {@link Builder} for method chaining
-         */
-        public Builder setThemeResId(int themeResId) {
-            mArgs.putInt(KEY_THEME_RES_ID, themeResId);
             return this;
         }
 

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -28,6 +28,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private static final String KEY_NEGATIVE_BUTTON_TEXT = "negative_button_text";
     private static final String KEY_OUTLINE_WIDTH = "border_width";
     private static final String KEY_FIXED_COLUMN_COUNT = "fixed_column_count";
+    private static final String KEY_THEME_RES_ID = "theme_res_id";
 
     private CharSequence mTitle;
     private CharSequence mPositiveButtonText;
@@ -39,6 +40,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private OnColorSelectedListener mListener;
     private int mOutlineWidth = 0;
     private int mFixedColumnCount = -1;
+    private int mThemeResId = 0;
 
     public SpectrumDialog() {
         // Required empty constructor
@@ -195,6 +197,17 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
         }
 
         /**
+         * Provides a resource that will be used to style to the dialog. See
+         * {@link AlertDialog#AlertDialog(Context, int)}.
+         *
+         * @return This {@link Builder} for method chaining
+         */
+        public Builder setThemeResId(int themeResId) {
+            mArgs.putInt(KEY_THEME_RES_ID, themeResId);
+            return this;
+        }
+
+        /**
          * Sets a listener to receive callbacks when the user interacts with the dialog.
          *
          * If you want this dialog to work properly across orientation changes, you should call
@@ -307,6 +320,10 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
             mFixedColumnCount = args.getInt(KEY_FIXED_COLUMN_COUNT);
         }
 
+        if (args != null && args.containsKey(KEY_THEME_RES_ID)) {
+            mThemeResId = args.getInt(KEY_THEME_RES_ID);
+        }
+
         // Next, overwrite any appropriate values if present in the saved instance state
         if (savedInstanceState != null && savedInstanceState.containsKey(KEY_SELECTED_COLOR)) {
             mSelectedColor = savedInstanceState.getInt(KEY_SELECTED_COLOR);
@@ -322,7 +339,12 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        AlertDialog.Builder builder;
+        if (mThemeResId != 0) {
+            builder = new AlertDialog.Builder(getContext(), mThemeResId);
+        } else {
+            builder = new AlertDialog.Builder(getContext());
+        }
 
         builder.setTitle(mTitle);
 


### PR DESCRIPTION
This adds an option to the dialog Builder to provide a theme attribute that will be passed through to the dialog we eventually construct. Provides functionality similar to `AlertDialog.Builder(Context context, int themeResId)`.

Fixes #33