### PR TITLE
Don't compute palette height if no colors set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.thebluealliance.spectrum"

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/PaletteDemoFragment.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/PaletteDemoFragment.java
@@ -15,8 +15,6 @@ public class PaletteDemoFragment extends Fragment implements SpectrumPalette.OnC
     @Nullable @Override public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_view_demo, container, false);
         SpectrumPalette spectrumPalette = (SpectrumPalette) v.findViewById(R.id.palette);
-        int[] colors = getResources().getIntArray(R.array.demo_colors);
-        spectrumPalette.setColors(colors);
         spectrumPalette.setOnColorSelectedListener(this);
         return v;
     }

--- a/sample/src/main/res/layout/fragment_view_demo.xml
+++ b/sample/src/main/res/layout/fragment_view_demo.xml
@@ -9,6 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:spectrum_autoPadding="true"
-        app:spectrum_outlineWidth="2dp" />
+        app:spectrum_outlineWidth="2dp"
+        app:spectrum_colors="@array/demo_colors" />
 
 </android.support.v4.widget.NestedScrollView>

--- a/spectrum/build.gradle
+++ b/spectrum/build.gradle
@@ -28,7 +28,7 @@ ext {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 15

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
@@ -183,6 +183,10 @@ public class SpectrumPalette extends LinearLayout {
     }
 
     private int computeHeight(int columnCount) {
+        if (mColors == null) {
+            // View does not have any colors to display, so we won't take up any room
+            return 0;
+        }
         int rowCount = mColors.length / columnCount;
         if (mColors.length % columnCount != 0) {
             rowCount++;


### PR DESCRIPTION
If there aren't any colors set via the XML attribute or programmatically, this prevents a crash when reading an empty array. This should never occur if used correctly, but issues could arise in the layout previewer if colors are set programmatically.

Fixes #35