### PR TITLE
Add outlineColor attribute, so it can be user defined

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 
 buildscript {
     repositories {
-        google()
         jcenter()
     }
     dependencies {
@@ -14,7 +13,6 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
         jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -13,6 +14,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.3'
 
     defaultConfig {
         applicationId "com.thebluealliance.spectrum"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -27,10 +27,17 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'com.android.support:preference-v7:23.2.1'
-    compile 'com.android.support:preference-v14:23.2.1'
-    compile 'com.android.support:design:23.2.1'
-    compile 'com.wada811:android-material-design-colors:3.0.0'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:preference-v7:25.4.0'
+    compile 'com.android.support:preference-v14:25.4.0'
+    compile 'com.android.support:design:25.4.0'
+    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.android.support:support-annotations:25.4.0'
+
+    // We already have appcompat, so we can ignore the older version
+    // that's used in this library
+    compile ('com.wada811:android-material-design-colors:3.0.0'){
+        exclude group: 'com.android.support'
+    }
     compile project(':spectrum')
 }

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
@@ -2,6 +2,7 @@ package com.thebluealliance.spectrumsample;
 
 import com.thebluealliance.spectrum.SpectrumDialog;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
 import android.support.v7.preference.Preference;
@@ -48,6 +49,14 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
         findPreference("demo_dialog_5").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override public boolean onPreferenceClick(Preference preference) {
                 showDialog5();
+                return true;
+            }
+        });
+
+        findPreference("demo_dialog_6").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                showDialog6();
                 return true;
             }
         });
@@ -141,26 +150,8 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
                 .setColors(R.array.demo_colors)
                 .setSelectedColorRes(R.color.md_blue_500)
                 .setDismissOnColorSelected(true)
-                .setOutlineWidth(2)
-                .setOutlineColor(R.color.md_black)
-                .setOnColorSelectedListener(new SpectrumDialog.OnColorSelectedListener() {
-                    @Override public void onColorSelected(boolean positiveResult, @ColorInt int color) {
-                        if (positiveResult) {
-                            Toast.makeText(getContext(), "Color selected: #" + Integer.toHexString(color).toUpperCase(), Toast.LENGTH_SHORT).show();
-                        } else {
-                            Toast.makeText(getContext(), "Dialog cancelled", Toast.LENGTH_SHORT).show();
-                        }
-                    }
-                }).build().show(getFragmentManager(), "dialog_demo_6");
-    }
-
-    private void showDialog7() {
-        new SpectrumDialog.Builder(getContext())
-                .setColors(R.array.demo_colors)
-                .setSelectedColorRes(R.color.md_blue_500)
-                .setDismissOnColorSelected(true)
-                .setOutlineWidth(2)
-                .setOutlineColor(R.color.md_pink_500)
+                .setOutlineWidth(6)
+                .setOutlineColor(Color.GREEN)
                 .setOnColorSelectedListener(new SpectrumDialog.OnColorSelectedListener() {
                     @Override public void onColorSelected(boolean positiveResult, @ColorInt int color) {
                         if (positiveResult) {

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
@@ -135,4 +135,41 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
                     }
                 }).build().show(getFragmentManager(), "dialog_demo_5");
     }
+
+    private void showDialog6() {
+        new SpectrumDialog.Builder(getContext())
+                .setColors(R.array.demo_colors)
+                .setSelectedColorRes(R.color.md_blue_500)
+                .setDismissOnColorSelected(true)
+                .setOutlineWidth(2)
+                .setOutlineColor(R.color.md_black)
+                .setOnColorSelectedListener(new SpectrumDialog.OnColorSelectedListener() {
+                    @Override public void onColorSelected(boolean positiveResult, @ColorInt int color) {
+                        if (positiveResult) {
+                            Toast.makeText(getContext(), "Color selected: #" + Integer.toHexString(color).toUpperCase(), Toast.LENGTH_SHORT).show();
+                        } else {
+                            Toast.makeText(getContext(), "Dialog cancelled", Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                }).build().show(getFragmentManager(), "dialog_demo_6");
+    }
+
+    private void showDialog7() {
+        new SpectrumDialog.Builder(getContext())
+                .setColors(R.array.demo_colors)
+                .setSelectedColorRes(R.color.md_blue_500)
+                .setDismissOnColorSelected(true)
+                .setOutlineWidth(2)
+                .setOutlineColor(R.color.md_pink_500)
+                .setOnColorSelectedListener(new SpectrumDialog.OnColorSelectedListener() {
+                    @Override public void onColorSelected(boolean positiveResult, @ColorInt int color) {
+                        if (positiveResult) {
+                            Toast.makeText(getContext(), "Color selected: #" + Integer.toHexString(color).toUpperCase(), Toast.LENGTH_SHORT).show();
+                        } else {
+                            Toast.makeText(getContext(), "Dialog cancelled", Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                }).build().show(getFragmentManager(), "dialog_demo_7");
+    }
+
 }

--- a/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
+++ b/sample/src/main/java/com/thebluealliance/spectrumsample/DialogDemoFragment.java
@@ -151,7 +151,7 @@ public class DialogDemoFragment extends PreferenceFragmentCompat {
                 .setSelectedColorRes(R.color.md_blue_500)
                 .setDismissOnColorSelected(true)
                 .setOutlineWidth(6)
-                .setOutlineColor(Color.GREEN)
+                .setOutlineColor(getResources().getColor(R.color.md_purple_300))
                 .setOnColorSelectedListener(new SpectrumDialog.OnColorSelectedListener() {
                     @Override public void onColorSelected(boolean positiveResult, @ColorInt int color) {
                         if (positiveResult) {

--- a/sample/src/main/res/xml/demo_dialog.xml
+++ b/sample/src/main/res/xml/demo_dialog.xml
@@ -13,7 +13,7 @@
 
     <Preference
         android:key="demo_dialog_6"
-        android:summary="This dialog has green outlines, you can set the outline to any color though"
+        android:summary="This dialog has purple outlines, you can set the outline to any color though"
         android:title="Click for a dialog with colored outlines"/>
 
     <Preference

--- a/sample/src/main/res/xml/demo_dialog.xml
+++ b/sample/src/main/res/xml/demo_dialog.xml
@@ -13,7 +13,7 @@
 
     <Preference
         android:key="demo_dialog_6"
-        android:summary="This dialog has purple outlines, you can set the outline to any color though"
+        android:summary="You can make all the colors have the same color border of your choosing"
         android:title="Click for a dialog with colored outlines"/>
 
     <Preference

--- a/sample/src/main/res/xml/demo_dialog.xml
+++ b/sample/src/main/res/xml/demo_dialog.xml
@@ -12,6 +12,11 @@
         android:title="Click for another dialog" />
 
     <Preference
+        android:key="demo_dialog_6"
+        android:summary="This dialog has green outlines, you can set the outline to any color though"
+        android:title="Click for a dialog with colored outlines"/>
+
+    <Preference
         android:key="demo_dialog_3"
         android:summary="This demonstrates Spectrum's behavior with a range of light and dark colors"
         android:title="256 Shades of Grey" />

--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -22,8 +22,8 @@
     <com.thebluealliance.spectrum.SpectrumPreferenceCompat
         android:defaultValue="@color/md_indigo_500"
         android:key="demo_preference_6"
-        android:summary="You can make all the colors have the same color border or your choosing"
-        android:title="Color preference with purple outlines"
+        android:summary="You can make all the colors have the same color border of your choosing"
+        android:title="Color preference with custom outline color"
         app:spectrum_colors="@array/demo_colors"
         app:spectrum_outlineWidth="2dp"
         app:spectrum_outlineColor="@color/md_purple_300"

--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -20,6 +20,23 @@
         app:spectrum_colors="@array/demo_colors_expanded" />
 
     <com.thebluealliance.spectrum.SpectrumPreferenceCompat
+        android:defaultValue="@color/md_indigo_500"
+        android:key="demo_preference_6"
+        android:summary="You can make all the colors have the same color border"
+        android:title="Color preference with homogenius outlines"
+        app:spectrum_colors="@array/demo_colors"
+        app:spectrum_outlineWidth="2dp"/>
+
+    <com.thebluealliance.spectrum.SpectrumPreferenceCompat
+        android:defaultValue="@color/md_red_500"
+        android:key="demo_preference_7"
+        android:summary="If black is too boring, you can change the border color to anything you want"
+        android:title="Another color preference with colored borders"
+        app:spectrum_closeOnSelected="true"
+        app:spectrum_outlineWidth="2dp"
+        app:spectrum_colors="@array/demo_colors_expanded" />
+
+    <com.thebluealliance.spectrum.SpectrumPreferenceCompat
         android:defaultValue="@color/md_red_500"
         android:key="demo_preference_3"
         android:summary="This preference has a fixed number of columns (4)."

--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -23,10 +23,10 @@
         android:defaultValue="@color/md_indigo_500"
         android:key="demo_preference_6"
         android:summary="You can make all the colors have the same color border or your choosing"
-        android:title="Color preference with green outlines"
+        android:title="Color preference with purple outlines"
         app:spectrum_colors="@array/demo_colors"
         app:spectrum_outlineWidth="2dp"
-        app:spectrum_outlineColor="@color/md_green_500"
+        app:spectrum_outlineColor="@color/md_purple_300"
         />
 
     <com.thebluealliance.spectrum.SpectrumPreferenceCompat

--- a/sample/src/main/res/xml/demo_preferences.xml
+++ b/sample/src/main/res/xml/demo_preferences.xml
@@ -22,19 +22,12 @@
     <com.thebluealliance.spectrum.SpectrumPreferenceCompat
         android:defaultValue="@color/md_indigo_500"
         android:key="demo_preference_6"
-        android:summary="You can make all the colors have the same color border"
-        android:title="Color preference with homogenius outlines"
+        android:summary="You can make all the colors have the same color border or your choosing"
+        android:title="Color preference with green outlines"
         app:spectrum_colors="@array/demo_colors"
-        app:spectrum_outlineWidth="2dp"/>
-
-    <com.thebluealliance.spectrum.SpectrumPreferenceCompat
-        android:defaultValue="@color/md_red_500"
-        android:key="demo_preference_7"
-        android:summary="If black is too boring, you can change the border color to anything you want"
-        android:title="Another color preference with colored borders"
-        app:spectrum_closeOnSelected="true"
         app:spectrum_outlineWidth="2dp"
-        app:spectrum_colors="@array/demo_colors_expanded" />
+        app:spectrum_outlineColor="@color/md_green_500"
+        />
 
     <com.thebluealliance.spectrum.SpectrumPreferenceCompat
         android:defaultValue="@color/md_red_500"

--- a/spectrum/build.gradle
+++ b/spectrum/build.gradle
@@ -27,12 +27,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode libraryVersionCode
         versionName libraryVersion
         consumerProguardFiles 'proguard-rules.pro'
@@ -47,10 +47,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:preference-v7:23.4.0'
-    compile 'com.android.support:support-annotations:23.4.0'
+    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:preference-v7:25.4.0'
+    compile 'com.android.support:support-annotations:25.4.0'
     compile 'org.greenrobot:eventbus:3.0.0'
 }
 

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -393,7 +393,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
         if (mOutlineWidth != 0) {
             palette.setOutlineWidth(mOutlineWidth);
         }
-        if (mOutlineColor > -1) {
+        if (mOutlineColor != -1) {
             palette.setOutlineColor(mOutlineColor);
         }
         if (mFixedColumnCount > 0) {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -393,7 +393,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
         if (mOutlineWidth != 0) {
             palette.setOutlineWidth(mOutlineWidth);
         }
-        if (mOutlineColor != null) {
+        if (mOutlineColor > -1) {
             palette.setOutlineColor(mOutlineColor);
         }
         if (mFixedColumnCount > 0) {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -40,7 +40,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private boolean mShouldDismissOnColorSelected = true;
     private OnColorSelectedListener mListener;
     private int mOutlineWidth = 0;
-    private @ColorInt int mOutlineColor = 0
+    private @ColorInt int mOutlineColor;
     private int mFixedColumnCount = -1;
     private int mThemeResId = 0;
 
@@ -393,7 +393,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
         if (mOutlineWidth != 0) {
             palette.setOutlineWidth(mOutlineWidth);
         }
-        if (mOutlineWidth != 0) {
+        if (mOutlineColor != null) {
             palette.setOutlineColor(mOutlineColor);
         }
         if (mFixedColumnCount > 0) {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -102,7 +102,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
          * @param color
          * @return This {@link Builder} for method chaining
          */
-        public Builder setOutlineWidth(@ColorInt int color) {
+        public Builder setOutlineColor(@ColorInt int color) {
             mArgs.putInt(KEY_OUTLINE_COLOR, color);
             return this;
         }

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -40,7 +40,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private boolean mShouldDismissOnColorSelected = true;
     private OnColorSelectedListener mListener;
     private int mOutlineWidth = 0;
-    private @ColorInt int mOutlineColor -1;
+    private @ColorInt int mOutlineColor = -1;
     private int mFixedColumnCount = -1;
     private int mThemeResId = 0;
 

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -27,6 +27,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private static final String KEY_POSITIVE_BUTTON_TEXT = "positive_button_text";
     private static final String KEY_NEGATIVE_BUTTON_TEXT = "negative_button_text";
     private static final String KEY_OUTLINE_WIDTH = "border_width";
+    private static final String KEY_OUTLINE_COLOR = "border_color";
     private static final String KEY_FIXED_COLUMN_COUNT = "fixed_column_count";
     private static final String KEY_THEME_RES_ID = "theme_res_id";
 
@@ -39,6 +40,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private boolean mShouldDismissOnColorSelected = true;
     private OnColorSelectedListener mListener;
     private int mOutlineWidth = 0;
+    private @ColorInt int mOutlineColor = 0
     private int mFixedColumnCount = -1;
     private int mThemeResId = 0;
 
@@ -90,6 +92,18 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
          */
         public Builder setOutlineWidth(int width) {
             mArgs.putInt(KEY_OUTLINE_WIDTH, width);
+            return this;
+        }
+        
+        
+        /**
+         * Change the color of the outlining
+         *
+         * @param color
+         * @return This {@link Builder} for method chaining
+         */
+        public Builder setOutlineWidth(@ColorInt int color) {
+            mArgs.putInt(KEY_OUTLINE_COLOR, color);
             return this;
         }
 
@@ -310,6 +324,10 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
         if (args != null && args.containsKey(KEY_OUTLINE_WIDTH)) {
             mOutlineWidth = args.getInt(KEY_OUTLINE_WIDTH);
         }
+        
+        if (args != null && args.containsKey(KEY_OUTLINE_COLOR)) {
+            mOutlineColor = args.getInt(KEY_OUTLINE_COLOR);
+        }
 
         if (args != null && args.containsKey(KEY_FIXED_COLUMN_COUNT)) {
             mFixedColumnCount = args.getInt(KEY_FIXED_COLUMN_COUNT);
@@ -374,6 +392,9 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
         palette.setOnColorSelectedListener(this);
         if (mOutlineWidth != 0) {
             palette.setOutlineWidth(mOutlineWidth);
+        }
+        if (mOutlineWidth != 0) {
+            palette.setOutlineColor(mOutlineColor);
         }
         if (mFixedColumnCount > 0) {
             palette.setFixedColumnCount(mFixedColumnCount);

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumDialog.java
@@ -40,7 +40,7 @@ public class SpectrumDialog extends DialogFragment implements SpectrumPalette.On
     private boolean mShouldDismissOnColorSelected = true;
     private OnColorSelectedListener mListener;
     private int mOutlineWidth = 0;
-    private @ColorInt int mOutlineColor;
+    private @ColorInt int mOutlineColor -1;
     private int mFixedColumnCount = -1;
     private int mThemeResId = 0;
 

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
@@ -334,7 +334,7 @@ public class SpectrumPalette extends LinearLayout {
      *
      * @param color
      */
-    public void setOutlineWidth(@ColorInt int color) {
+    public void setOutlineColor(@ColorInt int color) {
         mOutlineColor = color;
         for (ColorItem item : mItems) {
             item.setOutlineColor(color);

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
@@ -281,7 +281,7 @@ public class SpectrumPalette extends LinearLayout {
         if (mOutlineWidth != 0) {
             view.setOutlineWidth(mOutlineWidth);
         }
-        if (mOutlineColor > -1) {
+        if (mOutlineColor != -1) {
             view.setOutlineColor(mOutlineColor);
         }
         mItems.add(view);

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPalette.java
@@ -37,6 +37,7 @@ public class SpectrumPalette extends LinearLayout {
     private boolean mHasFixedColumnCount = false;
     private int mFixedColumnCount = -1;
     private int mOutlineWidth = 0;
+    private @ColorInt int mOutlineColor = -1;
     private int mComputedVerticalPadding = 0;
     private int mOriginalPaddingTop = 0;
     private int mOriginalPaddingBottom = 0;
@@ -67,6 +68,7 @@ public class SpectrumPalette extends LinearLayout {
 
         mAutoPadding = a.getBoolean(R.styleable.SpectrumPalette_spectrum_autoPadding, false);
         mOutlineWidth = a.getDimensionPixelSize(R.styleable.SpectrumPalette_spectrum_outlineWidth, 0);
+        mOutlineColor = a.getColor(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
         mFixedColumnCount = a.getInt(R.styleable.SpectrumPalette_spectrum_columnCount, -1);
         if (mFixedColumnCount != -1) {
             mHasFixedColumnCount = true;
@@ -279,6 +281,9 @@ public class SpectrumPalette extends LinearLayout {
         if (mOutlineWidth != 0) {
             view.setOutlineWidth(mOutlineWidth);
         }
+        if (mOutlineColor > -1) {
+            view.setOutlineColor(mOutlineColor);
+        }
         mItems.add(view);
         return view;
     }
@@ -324,6 +329,19 @@ public class SpectrumPalette extends LinearLayout {
         }
     }
 
+     /**
+     * Change the color of the outlining
+     *
+     * @param color
+     */
+    public void setOutlineWidth(@ColorInt int color) {
+        mOutlineColor = color;
+        for (ColorItem item : mItems) {
+            item.setOutlineColor(color);
+        }
+    }
+    
+    
     /**
      * Tells the palette to use a fixed number of columns during layout.
      *

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -29,6 +29,7 @@ public class SpectrumPreference extends DialogPreference {
     private boolean mValueSet = false;
     private View mColorView;
     private int mOutlineWidth = 0;
+    private @ColorInt int mOutlineColor = -1;
     private int mFixedColumnCount = -1;
 
     private SharedPreferences.OnSharedPreferenceChangeListener mListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
@@ -52,6 +53,7 @@ public class SpectrumPreference extends DialogPreference {
             }
             mCloseOnSelected = a.getBoolean(R.styleable.SpectrumPreference_spectrum_closeOnSelected, true);
             mOutlineWidth = a.getDimensionPixelSize(R.styleable.SpectrumPalette_spectrum_outlineWidth, 0);
+            mOutlineColor = a.getInt(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
             mFixedColumnCount = a.getInt(R.styleable.SpectrumPalette_spectrum_columnCount, -1);
         } finally {
             a.recycle();
@@ -163,6 +165,7 @@ public class SpectrumPreference extends DialogPreference {
         }
         ColorCircleDrawable drawable = new ColorCircleDrawable(mCurrentValue);
         drawable.setOutlineWidth(mOutlineWidth);
+        drawable.setOutlineColor(mOutlineColor);
         if (!isEnabled()) {
             // Show just a gray circle outline
             drawable.setColor(Color.BLACK);
@@ -191,6 +194,7 @@ public class SpectrumPreference extends DialogPreference {
         mColorPalette.setColors(mColors);
         mColorPalette.setSelectedColor(mCurrentValue);
         mColorPalette.setOutlineWidth(mOutlineWidth);
+        mColorPalette.setOutlineColor(mOutlineColor);
         mColorPalette.setFixedColumnCount(mFixedColumnCount);
         mColorPalette.setOnColorSelectedListener(new SpectrumPalette.OnColorSelectedListener() {
             @Override

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreference.java
@@ -53,7 +53,7 @@ public class SpectrumPreference extends DialogPreference {
             }
             mCloseOnSelected = a.getBoolean(R.styleable.SpectrumPreference_spectrum_closeOnSelected, true);
             mOutlineWidth = a.getDimensionPixelSize(R.styleable.SpectrumPalette_spectrum_outlineWidth, 0);
-            mOutlineColor = a.getInt(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
+            mOutlineColor = a.getColor(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
             mFixedColumnCount = a.getInt(R.styleable.SpectrumPalette_spectrum_columnCount, -1);
         } finally {
             a.recycle();

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -76,7 +76,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
             }
             mCloseOnSelected = a.getBoolean(R.styleable.SpectrumPreference_spectrum_closeOnSelected, true);
             mOutlineWidth = a.getDimensionPixelSize(R.styleable.SpectrumPalette_spectrum_outlineWidth, 0);
-            mOutlineWidth = a.getInt(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
+            mOutlineWidth = a.getColor(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
             mFixedColumnCount = a.getInt(R.styleable.SpectrumPalette_spectrum_columnCount, -1);
         } finally {
             a.recycle();

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -53,7 +53,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
     private boolean mValueSet = false;
     private View mColorView;
     private int mOutlineWidth = 0;
-    private @ColorInt int mOutlineColor;
+    private @ColorInt int mOutlineColor = -1;
     private int mFixedColumnCount = -1;
 
     private SharedPreferences.OnSharedPreferenceChangeListener mListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
@@ -76,7 +76,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
             }
             mCloseOnSelected = a.getBoolean(R.styleable.SpectrumPreference_spectrum_closeOnSelected, true);
             mOutlineWidth = a.getDimensionPixelSize(R.styleable.SpectrumPalette_spectrum_outlineWidth, 0);
-            mOutlineWidth = a.getColor(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
+            mOutlineColor = a.getColor(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
             mFixedColumnCount = a.getInt(R.styleable.SpectrumPalette_spectrum_columnCount, -1);
         } finally {
             a.recycle();

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/SpectrumPreferenceCompat.java
@@ -53,6 +53,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
     private boolean mValueSet = false;
     private View mColorView;
     private int mOutlineWidth = 0;
+    private @ColorInt int mOutlineColor;
     private int mFixedColumnCount = -1;
 
     private SharedPreferences.OnSharedPreferenceChangeListener mListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
@@ -75,6 +76,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
             }
             mCloseOnSelected = a.getBoolean(R.styleable.SpectrumPreference_spectrum_closeOnSelected, true);
             mOutlineWidth = a.getDimensionPixelSize(R.styleable.SpectrumPalette_spectrum_outlineWidth, 0);
+            mOutlineWidth = a.getInt(R.styleable.SpectrumPalette_spectrum_outlineColor, -1);
             mFixedColumnCount = a.getInt(R.styleable.SpectrumPalette_spectrum_columnCount, -1);
         } finally {
             a.recycle();
@@ -157,6 +159,7 @@ public class SpectrumPreferenceCompat extends DialogPreference {
         }
         ColorCircleDrawable drawable = new ColorCircleDrawable(mCurrentValue);
         drawable.setOutlineWidth(mOutlineWidth);
+        drawable.setOutlineColor(mOutlineColor);
         if (!isEnabled()) {
             // Show just a gray circle outline
             drawable.setColor(Color.WHITE);
@@ -206,6 +209,10 @@ public class SpectrumPreferenceCompat extends DialogPreference {
 
     public int getOutlineWidth() {
         return mOutlineWidth;
+    }
+    
+    public int getOutlineColor() {
+        return mOutlineColor;
     }
 
     public int getFixedColumnCount() {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorCircleDrawable.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorCircleDrawable.java
@@ -13,7 +13,6 @@ public class ColorCircleDrawable extends Drawable {
     private final Paint mPaint;
     private int mRadius = 0;
     private int mOutlineWidth = 0;
-    private @ColorInt int mOutlineColor = -1;
     private final Paint mOutlinePaint;
 
     public ColorCircleDrawable(final @ColorInt int color) {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorCircleDrawable.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorCircleDrawable.java
@@ -13,6 +13,7 @@ public class ColorCircleDrawable extends Drawable {
     private final Paint mPaint;
     private int mRadius = 0;
     private int mOutlineWidth = 0;
+    private @ColorInt int mOutlineColor = -1;
     private final Paint mOutlinePaint;
 
     public ColorCircleDrawable(final @ColorInt int color) {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
@@ -34,6 +34,7 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
     private @ColorInt int mColor;
     private boolean mIsSelected = false;
     private int mOutlineWidth = 0;
+    private @ColorInt int mOutlineColor = 0;
 
     public ColorItem(Context context, @ColorInt int color, boolean isSelected, EventBus eventBus) {
         super(context);
@@ -83,6 +84,16 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
      */
     public void setOutlineWidth(int width) {
         mOutlineWidth = width;
+        updateDrawables();
+    }
+    
+     /**
+     * Force an outline color instead of setting
+     * to black or white (default behavior)
+     * @param color
+     */
+    public void setOutlineColor(@ColorInt int color) {
+        mOutlineColor = color;
         updateDrawables();
     }
 
@@ -163,7 +174,12 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
         GradientDrawable mask = new GradientDrawable();
         mask.setShape(GradientDrawable.OVAL);
         if (mOutlineWidth != 0) {
-            mask.setStroke(mOutlineWidth, ColorUtil.isColorDark(mColor) ? Color.WHITE : Color.BLACK);
+            if (mOutlineColor != null) {
+                mask.setStroke(mOutlineWidth, mOutlineColor);
+            }
+            else {
+                mask.setStroke(mOutlineWidth, ColorUtil.isColorDark(mColor) ? Color.WHITE : Color.BLACK);
+            }
         }
         mask.setColor(mColor);
         return mask;

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
@@ -174,7 +174,7 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
         GradientDrawable mask = new GradientDrawable();
         mask.setShape(GradientDrawable.OVAL);
         if (mOutlineWidth != 0) {
-            if (mOutlineColor > -1) {
+            if (mOutlineColor != -1) {
                 mask.setStroke(mOutlineWidth, mOutlineColor);
             }
             else {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
@@ -88,8 +88,8 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
     }
     
      /**
-     * Force an outline color instead of setting
-     * to black or white (default behavior)
+     * Override the default outline color
+     * 
      * @param color
      */
     public void setOutlineColor(@ColorInt int color) {
@@ -176,8 +176,7 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
         if (mOutlineWidth != 0) {
             if (mOutlineColor != -1) {
                 mask.setStroke(mOutlineWidth, mOutlineColor);
-            }
-            else {
+            } else {
                 mask.setStroke(mOutlineWidth, ColorUtil.isColorDark(mColor) ? Color.WHITE : Color.BLACK);
             }
         }

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/ColorItem.java
@@ -34,7 +34,7 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
     private @ColorInt int mColor;
     private boolean mIsSelected = false;
     private int mOutlineWidth = 0;
-    private @ColorInt int mOutlineColor = 0;
+    private @ColorInt int mOutlineColor = -1;
 
     public ColorItem(Context context, @ColorInt int color, boolean isSelected, EventBus eventBus) {
         super(context);
@@ -174,7 +174,7 @@ public class ColorItem extends FrameLayout implements View.OnClickListener {
         GradientDrawable mask = new GradientDrawable();
         mask.setShape(GradientDrawable.OVAL);
         if (mOutlineWidth != 0) {
-            if (mOutlineColor != null) {
+            if (mOutlineColor > -1) {
                 mask.setStroke(mOutlineWidth, mOutlineColor);
             }
             else {

--- a/spectrum/src/main/java/com/thebluealliance/spectrum/internal/SpectrumPreferenceDialogFragmentCompat.java
+++ b/spectrum/src/main/java/com/thebluealliance/spectrum/internal/SpectrumPreferenceDialogFragmentCompat.java
@@ -54,6 +54,7 @@ public class SpectrumPreferenceDialogFragmentCompat extends PreferenceDialogFrag
         mColorPalette.setColors(getSpectrumPreference().getColors());
         mColorPalette.setSelectedColor(mCurrentValue);
         mColorPalette.setOutlineWidth(getSpectrumPreference().getOutlineWidth());
+        mColorPalette.setOutlineColor(getSpectrumPreference().getOutlineColor());
         mColorPalette.setFixedColumnCount(getSpectrumPreference().getFixedColumnCount());
         mColorPalette.setOnColorSelectedListener(new SpectrumPalette.OnColorSelectedListener() {
             @Override

--- a/spectrum/src/main/res/values/attrs.xml
+++ b/spectrum/src/main/res/values/attrs.xml
@@ -2,11 +2,13 @@
 <resources>
     <attr name="spectrum_colors" format="reference" />
     <attr name="spectrum_outlineWidth" format="dimension" />
+    <attr name="spectrum_outlineColor" format="color" />
     <attr name="spectrum_columnCount" format="integer" />
 
     <declare-styleable name="SpectrumPalette">
         <attr name="spectrum_colors" />
         <attr name="spectrum_outlineWidth" />
+        <attr name="spectrum_outlineColor" />
         <attr name="spectrum_columnCount" />
         <attr name="spectrum_autoPadding" format="boolean" />
     </declare-styleable>
@@ -14,6 +16,7 @@
     <declare-styleable name="SpectrumPreference">
         <attr name="spectrum_colors" />
         <attr name="spectrum_outlineWidth" />
+        <attr name="spectrum_outlineColor" />
         <attr name="spectrum_columnCount" />
         <attr name="spectrum_closeOnSelected" format="boolean" />
     </declare-styleable>


### PR DESCRIPTION
In response to https://github.com/the-blue-alliance/spectrum/issues/17

This adds a 'outlineColor' attribute that will override the black/white border that the library sets. If user does not define 'outlineColor' then nothing changes, but if they do, the outline will always have that color (assuming that width is set)

![outline_in_omnichan_app](https://user-images.githubusercontent.com/464971/28226039-a661d466-68a2-11e7-837b-738fd4b01fe5.png)
